### PR TITLE
Add `picture` to simplify using images

### DIFF
--- a/_plugins/picture_tag.rb
+++ b/_plugins/picture_tag.rb
@@ -1,0 +1,28 @@
+module Jekyll
+  class PictureTag < Liquid::Block
+    def initialize(tag_name, input, options)
+      super
+
+      @input = input
+    end
+
+    def render(context)
+      text = super
+      url = input.strip
+      description = text.strip
+
+      <<~OUTPUT
+        <figure>
+          <img src="#{url}" alt="#{description}" max-width="500px" />
+          <figcaption>#{description}</figcaption>
+        </figure>
+      OUTPUT
+    end
+
+    private
+
+    attr_reader :input
+  end
+end
+
+Liquid::Template.register_tag('picture', Jekyll::PictureTag)

--- a/_posts/2021-11-21-switching-to-feedbin-and-netnewswire.md
+++ b/_posts/2021-11-21-switching-to-feedbin-and-netnewswire.md
@@ -43,11 +43,9 @@ not a big deal. News isn't like that, and there's often regular stories I
 immediately mark as read. With Feedbin's Actions, I could automate marking
 stuff as read. That's wonderful.
 
-<figure>
-  <img src="/resources/images/feedbin-actions.png"
-  alt="An example of Feedbin's Actions auto-mark as read feature" max-width="500px">
-  <figcaption>An example of Feedbin's Actions auto-mark as read feature</figcaption>
-</figure>
+{% picture /resources/images/feedbin-actions.png %}
+  An example of Feedbin's Actions auto-mark as read feature
+{% endpicture %}
 
 Migrating was a bit of a challenge. I don't keep anything like RSS reader inbox
 zero. Mostly recently, I've been avoiding it too, as it hasn't been working

--- a/spec/picture_tag_spec.rb
+++ b/spec/picture_tag_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+require_relative "../_plugins/picture_tag"
+
+RSpec.describe Jekyll::PictureTag do
+  it "renders with a url and description" do
+    output = render(
+      <<~SNIPPET
+      {% picture some_url %}
+      Some description
+      {% endpicture %}
+      SNIPPET
+    )
+
+    expect(output).to eq(
+      <<~OUTPUT
+        <figure>
+          <img src="some_url" alt="Some description" max-width="500px" />
+          <figcaption>Some description</figcaption>
+        </figure>\n
+      OUTPUT
+    )
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,46 @@
 require "rspec"
 
 require "jekyll"
+
+TEST_DIR = File.dirname(__FILE__)
+TMP_DIR  = File.expand_path("../tmp", TEST_DIR)
+
+def tmp_dir(*files)
+  File.join(TMP_DIR, *files)
+end
+
+def source_dir(*files)
+  tmp_dir("source", *files)
+end
+
+def dest_dir(*files)
+  tmp_dir("dest", *files)
+end
+
+def build_site(opts = {})
+  defaults = Jekyll::Configuration::DEFAULTS
+  opts = opts.merge(
+    source: source_dir,
+    destination: dest_dir
+  )
+  conf = Jekyll::Utils.deep_merge_hashes(defaults, opts)
+  Jekyll::Site.new(conf)
+end
+
+def collection(site, label = "test")
+  Jekyll::Collection.new(site, label)
+end
+
+def build_doc(opts = {})
+  site = build_site(opts)
+  options = { site: site, collection: collection(site) }
+  doc = Jekyll::Document.new(source_dir("_test/doc.md"), options)
+  doc.merge_data!({ author: "test" })
+  doc
+end
+
+def render(content)
+  doc = build_doc
+  doc.content = content
+  doc.output = Jekyll::Renderer.new(doc.site, doc).run
+end


### PR DESCRIPTION
This makes it easier to insert images into posts, allowing:

    {% picture /path/to/image.png %}
    Some description
    {% endpicture %}

This uses a bunch of inspiration from `jekyll-avatar`, which had the
least worst test setup around. Unfortunately, we still need to generate
a whole site to test out a tag.

https://jekyllrb.com/docs/plugins/tags/
https://github.com/jekyll/jekyll-avatar/blob/192986e31b8591d3d9f02e2fe6e9009d620b7a70/spec/spec_helper.rb