### PR TITLE
Enhance picture tag with alt text and absolute_url

### DIFF
--- a/_plugins/picture_tag.rb
+++ b/_plugins/picture_tag.rb
@@ -1,19 +1,32 @@
 module Jekyll
   class PictureTag < Liquid::Block
+    QuotedString = /"[^"]*"|'[^']*'/
+    QuotedFragment = /#{QuotedString}|(?:[^\s,\|'"]|#{QuotedString})+/o
+    TagAttributes = /(\w[\w-]*)\s*\:\s*(#{QuotedFragment})/o
+
     def initialize(tag_name, input, options)
       super
 
-      @input = input
+      @attributes = {}
+      input.scan(TagAttributes) do |key, value|
+        @attributes[key] = attribute_parse(value)
+      end
+
+      unless attributes.key?("url")
+        raise SyntaxError, "picture must have a `url:`" 
+      end
     end
 
     def render(context)
       text = super
-      url = input.strip
+      url = attributes["url"]
+      alt = attributes["alt"]
+      alt_tag = "alt=\"#{alt}\"" if alt
       description = text.strip
 
       <<~OUTPUT
         <figure>
-          <img src="#{url}" alt="#{description}" max-width="500px" />
+          <img src="{{ #{url} | absolute_url }}" #{alt_tag} max-width="500px" />
           <figcaption>#{description}</figcaption>
         </figure>
       OUTPUT
@@ -21,7 +34,17 @@ module Jekyll
 
     private
 
-    attr_reader :input
+    attr_reader :attributes
+
+    def attribute_parse(markup)
+      markup = markup.strip
+      if (markup.start_with?('"') && markup.end_with?('"')) ||
+          (markup.start_with?("'") && markup.end_with?("'"))
+        return markup[1..-2]
+      end
+
+      markup
+    end
   end
 end
 

--- a/_posts/2021-11-21-switching-to-feedbin-and-netnewswire.md
+++ b/_posts/2021-11-21-switching-to-feedbin-and-netnewswire.md
@@ -43,7 +43,7 @@ not a big deal. News isn't like that, and there's often regular stories I
 immediately mark as read. With Feedbin's Actions, I could automate marking
 stuff as read. That's wonderful.
 
-{% picture /resources/images/feedbin-actions.png %}
+{% picture url: /resources/images/feedbin-actions.png %}
   An example of Feedbin's Actions auto-mark as read feature
 {% endpicture %}
 

--- a/spec/picture_tag_spec.rb
+++ b/spec/picture_tag_spec.rb
@@ -2,10 +2,24 @@ require "spec_helper"
 require_relative "../_plugins/picture_tag"
 
 RSpec.describe Jekyll::PictureTag do
+  it "raises unless url is provided" do
+    silence do
+      expect do
+        render(
+          <<~SNIPPET
+        {% picture %}
+        Some description
+        {% endpicture %}
+          SNIPPET
+        )
+      end.to raise_error(SyntaxError)
+    end
+  end
+
   it "renders with a url and description" do
     output = render(
       <<~SNIPPET
-      {% picture some_url %}
+      {% picture url: some_url %}
       Some description
       {% endpicture %}
       SNIPPET
@@ -14,7 +28,26 @@ RSpec.describe Jekyll::PictureTag do
     expect(output).to eq(
       <<~OUTPUT
         <figure>
-          <img src="some_url" alt="Some description" max-width="500px" />
+          <img src="{{ some_url | absolute_url }}" max-width="500px" />
+          <figcaption>Some description</figcaption>
+        </figure>\n
+      OUTPUT
+    )
+  end
+
+  it "renders with a url, description and alt text" do
+    output = render(
+      <<~SNIPPET
+      {% picture url: some_url, alt: "Some alt text" %}
+      Some description
+      {% endpicture %}
+      SNIPPET
+    )
+
+    expect(output).to eq(
+      <<~OUTPUT
+        <figure>
+          <img src="{{ some_url | absolute_url }}" alt="Some alt text" max-width="500px" />
           <figcaption>Some description</figcaption>
         </figure>\n
       OUTPUT

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,3 +44,17 @@ def render(content)
   doc.content = content
   doc.output = Jekyll::Renderer.new(doc.site, doc).run
 end
+
+def silence
+  @original_stderr = $stderr
+  @original_stdout = $stdout
+
+  $stderr = $stdout = StringIO.new
+
+  yield
+
+  $stderr = @original_stderr
+  $stdout = @original_stdout
+  @original_stderr = nil
+  @original_stdout = nil
+end


### PR DESCRIPTION
This fixes two problems with `picture`:

1. Images in RSS were broken, because the URL wasn't absolute,
2. We weren't able to provide alt text seperate from the image caption, which meant that alt text wasn't very good.

This is done by taking some code from Liquid which isn't supported in Jekyll yet and adding arguments to tags inspired by Liquid 5.0.0's `render`: https://shopify.github.io/liquid/tags/template/

We take the `input` value (known as `markup` in Liquid), parse it with some regular expressions and then tidy it up a bit. We didn't need more than what's taken here, but the source material supports a lot more than this.

If the `url:` parameter isn't provided, we raise a syntax error. Jekyll causes some output here, so we also need to silence that. In future it might be nice to warn on no `alt` text too.

This commit also updates previous references to the picture tag.

https://github.com/Shopify/liquid/blob/c99c93255d55129652e262e87c27d359628f71e6/lib/liquid/tags/render.rb https://github.com/Shopify/liquid/blob/c99c93255d55129652e262e87c27d359628f71e6/lib/liquid/expression.rb http://michaelay.github.io/blog/2014/12/15/suppress-stdout-and-stderr-when-running-rspec/