### PR TITLE
Fix filter usage in tags

### DIFF
--- a/_plugins/picture_tag.rb
+++ b/_plugins/picture_tag.rb
@@ -1,5 +1,7 @@
 module Jekyll
   class PictureTag < Liquid::Block
+    include Filters::URLFilters
+
     QuotedString = /"[^"]*"|'[^']*'/
     QuotedFragment = /#{QuotedString}|(?:[^\s,\|'"]|#{QuotedString})+/o
     TagAttributes = /(\w[\w-]*)\s*\:\s*(#{QuotedFragment})/o
@@ -19,14 +21,15 @@ module Jekyll
 
     def render(context)
       text = super
-      url = attributes["url"]
+      @context = context
+      url = absolute_url(attributes["url"])
       alt = attributes["alt"]
       alt_tag = "alt=\"#{alt}\"" if alt
       description = text.strip
 
       <<~OUTPUT
         <figure>
-          <img src="{{ #{url} | absolute_url }}" #{alt_tag} max-width="500px" />
+          <img src="#{url}" #{alt_tag} max-width="500px" />
           <figcaption>#{description}</figcaption>
         </figure>
       OUTPUT

--- a/spec/picture_tag_spec.rb
+++ b/spec/picture_tag_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Jekyll::PictureTag do
     expect(output).to eq(
       <<~OUTPUT
         <figure>
-          <img src="{{ some_url | absolute_url }}" max-width="500px" />
+          <img src="/some_url" max-width="500px" />
           <figcaption>Some description</figcaption>
         </figure>\n
       OUTPUT
@@ -47,7 +47,7 @@ RSpec.describe Jekyll::PictureTag do
     expect(output).to eq(
       <<~OUTPUT
         <figure>
-          <img src="{{ some_url | absolute_url }}" alt="Some alt text" max-width="500px" />
+          <img src="/some_url" alt="Some alt text" max-width="500px" />
           <figcaption>Some description</figcaption>
         </figure>\n
       OUTPUT


### PR DESCRIPTION
It turns out you can't use a Liquid filter inside a tag, so the previous commit broke when used.

This pulls in the existing filter and uses it directly — we need to make the context accessible, but otherwise it's not too bad.

In the mock site used for the tests, the `site_url` isn't set so all we get is the addition of `/` but that's fine for now.

https://github.com/nickcharlton/site/commit/b9f880b38534243096a523a7c2ef0ec9c9f8d1a4