### PR TITLE
Remove published frontmatter

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -34,7 +34,6 @@ task :new do
   template = <<END
 ---
 title: "#{post_name}"
-published: #{post_date.strftime('%Y-%m-%d %H-%M-%S %:z')}
 tags: #{post_tags}
 ---
 END

--- a/_posts/2008-06-24-setting-up-lm-sensors-on-debian-etch.md
+++ b/_posts/2008-06-24-setting-up-lm-sensors-on-debian-etch.md
@@ -1,6 +1,5 @@
 ---
 title: Setting Up lm-sensors on Debian Etch
-published: 2008-06-24 08:00:00 +0000
 tags: 
 ---
 

--- a/_posts/2008-11-01-converting-a-sparseimage-to-a-dmg.md
+++ b/_posts/2008-11-01-converting-a-sparseimage-to-a-dmg.md
@@ -1,6 +1,5 @@
 ---
 title: Converting a sparseimage to a dmg
-published: 2008-11-01 07:00:00 +0000
 tags: 
 ---
 

--- a/_posts/2009-02-25-dns-testing-tools.md
+++ b/_posts/2009-02-25-dns-testing-tools.md
@@ -1,6 +1,5 @@
 ---
 title: DNS Testing Tools
-published: 2009-02-25 08:00:00 +0000
 tags: 
 ---
 

--- a/_posts/2009-04-05-using-apachebench.md
+++ b/_posts/2009-04-05-using-apachebench.md
@@ -1,6 +1,5 @@
 ---
 title: Using 'ab', ApacheBench to test Web Server Performance
-published: 2009-04-05 08:00:00 +0000
 tags: 
 ---
 

--- a/_posts/2009-05-08-ubuntu-on-sdcard.md
+++ b/_posts/2009-05-08-ubuntu-on-sdcard.md
@@ -1,6 +1,5 @@
 ---
 title: Installing Ubuntu 9.04 on an SD card
-published: 2009-05-08 08:00:00 +0000
 tags: ubuntu, sd-card
 ---
 

--- a/_posts/2009-05-18-introduction-to-sqlite-2-with-php-5.md
+++ b/_posts/2009-05-18-introduction-to-sqlite-2-with-php-5.md
@@ -1,6 +1,5 @@
 ---
 title: Introduction to SQLite 2 with PHP 5
-published: 2009-05-18 08:00:00 +0000
 tags: php, sqlite
 ---
 

--- a/_posts/2009-06-24-ssh-banner-debian.md
+++ b/_posts/2009-06-24-ssh-banner-debian.md
@@ -1,6 +1,5 @@
 ---
 title: Configuring an SSH banner on Debian
-published: 2009-06-24 08:00:00 +0000
 tags: debian, ssh
 ---
 

--- a/_posts/2009-06-26-configuring-sudo-on-debian.md
+++ b/_posts/2009-06-26-configuring-sudo-on-debian.md
@@ -1,6 +1,5 @@
 ---
 title: Configuring Sudo on Debian
-published: 2009-06-26 08:00:00 +0000
 tags: debian, sudo, security
 ---
 

--- a/_posts/2009-09-11-public-key-auth-screencast.md
+++ b/_posts/2009-09-11-public-key-auth-screencast.md
@@ -1,6 +1,5 @@
 ---
 title: Public Key Auth Screencast
-published: 2009-09-11 08:00:00 +0000
 tags: ssh, security, screencast
 ---
 

--- a/_posts/2009-09-12-new-macbook-pro.md
+++ b/_posts/2009-09-12-new-macbook-pro.md
@@ -1,6 +1,5 @@
 ---
 title: New MacBook Pro
-published: 2009-09-12 08:00:00 +0000
 tags: macbook-pro
 ---
 

--- a/_posts/2009-09-18-ssh-public-key-screencast-notes.md
+++ b/_posts/2009-09-18-ssh-public-key-screencast-notes.md
@@ -1,6 +1,5 @@
 ---
 title: SSH Public Key Screencast Notes
-published: 2009-09-18 08:00:00 +0000
 tags: ssh, security, screencast
 ---
 

--- a/_posts/2009-10-05-jekyll-and-github.md
+++ b/_posts/2009-10-05-jekyll-and-github.md
@@ -1,6 +1,5 @@
 ---
 title: Jekyll and GitHub
-published: 2009-10-05 08:00:00 +0000
 tags: jekyll, github, blogging
 ---
 

--- a/_posts/2009-11-03-ideas-and-university.md
+++ b/_posts/2009-11-03-ideas-and-university.md
@@ -1,6 +1,5 @@
 ---
 title: Ideas and University
-published: 2009-11-03 08:00:00 +0000
 tags: ideas, university, thoughts
 ---
 

--- a/_posts/2010-01-27-thoughts-ipad.md
+++ b/_posts/2010-01-27-thoughts-ipad.md
@@ -1,6 +1,5 @@
 ---
 title: Thoughts on the iPad
-published: 2010-01-27 08:00:00 +0000
 tags: 
 ---
 

--- a/_posts/2010-02-26-fixing-missing-gem-problems.md
+++ b/_posts/2010-02-26-fixing-missing-gem-problems.md
@@ -1,6 +1,5 @@
 ---
 title: Fixing Missing Gem Problems on OS X
-published: 2010-02-26 08:00:00 +0000
 tags: 
 ---
 

--- a/_posts/2010-04-14-sqlite-with-csharp.md
+++ b/_posts/2010-04-14-sqlite-with-csharp.md
@@ -1,6 +1,5 @@
 ---
 title: SQLite, ADO.NET & CSharp
-published: 2010-04-14 08:00:00 +0000
 tags: dotnet, csharp, sqlite
 ---
 

--- a/_posts/2010-05-30-new-project.md
+++ b/_posts/2010-05-30-new-project.md
@@ -1,6 +1,5 @@
 ---
 title: New Project
-published: 2010-05-30 00:42:13 +0000
 tags: blog, sinba
 ---
 

--- a/_posts/2010-07-10-css3-bundle.md
+++ b/_posts/2010-07-10-css3-bundle.md
@@ -1,6 +1,5 @@
 ---
 title: CSS3 Bundle
-published: 2010-07-10 11:49:40 +0000
 tags: css3, textmate, bundle, projects
 ---
 

--- a/_posts/2010-09-17-on-long-way-down.md
+++ b/_posts/2010-09-17-on-long-way-down.md
@@ -1,6 +1,5 @@
 ---
 title: On Long Way Down
-published: 2010-09-17 00:18:39 +0000
 tags: book, adventure, long-way-down
 ---
 

--- a/_posts/2010-09-29-bcs-lecture-series-apple-the-birth-of-a-third-platform.md
+++ b/_posts/2010-09-29-bcs-lecture-series-apple-the-birth-of-a-third-platform.md
@@ -1,6 +1,5 @@
 ---
 title: "BCS Lecture Series: Apple (The Birth of a Third Platform)"
-published: 2010-09-29 09:24:06 +0000
 tags: lecture, apple, mobile
 ---
 

--- a/_posts/2010-11-10-bcs-lecture-series-physical-security-in-it.md
+++ b/_posts/2010-11-10-bcs-lecture-series-physical-security-in-it.md
@@ -1,6 +1,5 @@
 ---
 title: "BCS Lecture Series: Physical Security in IT"
-published: 2010-11-10 00:25:21 +0000
 tags: bcs, lecture, infosec, physical security
 ---
 

--- a/_posts/2010-12-26-progcomp-a-programming-competitions-blog.md
+++ b/_posts/2010-12-26-progcomp-a-programming-competitions-blog.md
@@ -1,6 +1,5 @@
 ---
 title: "ProgComp: A Programming Competitions Blog"
-published: 2010-12-26 21:47:36 +0000
 tags: projects, progcomp, programming
 ---
 

--- a/_posts/2011-02-06-guide-to-sax-in-java.md
+++ b/_posts/2011-02-06-guide-to-sax-in-java.md
@@ -1,6 +1,5 @@
 ---
 title: An Ultra-simple Guide to Reading XML in Java, using SAX
-published: 2011-02-06 14:17:43 +0000
 tags: java, xml, sax
 ---
 

--- a/_posts/2011-02-08-termisoc-hack-weekend-2011.md
+++ b/_posts/2011-02-08-termisoc-hack-weekend-2011.md
@@ -1,6 +1,5 @@
 ---
 title: TermiSoc Hack Weekend 2011
-published: 2011-02-08 16:54:27 +0000
 tags: termisoc, hack-weekend, python, app-engine, mobile, location, arduino
 ---
 

--- a/_posts/2011-03-02-using-rubyoci8-on-ubuntudebian.md
+++ b/_posts/2011-03-02-using-rubyoci8-on-ubuntudebian.md
@@ -1,6 +1,5 @@
 ---
 title: Using ruby-oci8 on Ubuntu/Debian
-published: 2011-03-02 14:43:36 +0000
 tags: ruby, oracle, ruby-oci8, ubuntu, debian
 ---
 

--- a/_posts/2011-03-07-the-digital-peninsulas-first-web-unconference.md
+++ b/_posts/2011-03-07-the-digital-peninsulas-first-web-unconference.md
@@ -1,6 +1,5 @@
 ---
 title: The Digital Peninsula's First Web Unconference
-published: 2011-03-07 09:45:08 +0000
 tags: digpen, termisoc, unconference, digital peninsula
 ---
 

--- a/_posts/2011-03-22-review-arduino-cookbook-by-michael-margolis.md
+++ b/_posts/2011-03-22-review-arduino-cookbook-by-michael-margolis.md
@@ -1,6 +1,5 @@
 ---
 title: "Review: Arduino Cookbook by Michael Margolis"
-published: 2011-03-22 12:17:24 +0000
 tags: review, arduino
 ---
 

--- a/_posts/2011-05-11-building-custom-android-listviews.md
+++ b/_posts/2011-05-11-building-custom-android-listviews.md
@@ -1,6 +1,5 @@
 ---
 title: Building Custom Android ListViews
-published: 2011-05-11 18:20:14 +0000
 tags: android, listview, java
 ---
 

--- a/_posts/2011-05-15-digital-peninsula-unconference-ii-exeter.md
+++ b/_posts/2011-05-15-digital-peninsula-unconference-ii-exeter.md
@@ -1,6 +1,5 @@
 ---
 title: Digital Peninsula Unconference II, Exeter
-published: 2011-05-15 21:02:39 +0000
 tags: digpen, unconference, digital peninsula
 ---
 

--- a/_posts/2011-06-12-digital-peninsula-unconference-iii-falmouth.md
+++ b/_posts/2011-06-12-digital-peninsula-unconference-iii-falmouth.md
@@ -1,6 +1,5 @@
 ---
 title: Digital Peninsula Unconference III, Falmouth
-published: 2011-06-12 19:14:35 +0000
 tags: photos, digpen, falmouth, unconference
 ---
 

--- a/_posts/2011-06-13-thoughts-on-the-uop-intellectual-property-agreement.md
+++ b/_posts/2011-06-13-thoughts-on-the-uop-intellectual-property-agreement.md
@@ -1,6 +1,5 @@
 ---
 title: Thoughts on the UoP Intellectual Property Agreement
-published: 2011-06-13 16:12:24 +0000
 tags: uop, ip
 ---
 

--- a/_posts/2011-07-26-starting-at-rokk-media.md
+++ b/_posts/2011-07-26-starting-at-rokk-media.md
@@ -1,6 +1,5 @@
 ---
 title: Starting at Rokk Media
-published: 2011-07-26 16:19:07 +0000
 tags: rokk-media, placement, iOS
 ---
 

--- a/_posts/2011-08-12-wheres-next-now-in-the-app-store.md
+++ b/_posts/2011-08-12-wheres-next-now-in-the-app-store.md
@@ -1,6 +1,5 @@
 ---
 title: Where's Next? Now In the App Store.
-published: 2011-08-12 05:38:29 +0000
 tags: app, iphone, projects
 ---
 

--- a/_posts/2011-08-18-wheres-next-101-release.md
+++ b/_posts/2011-08-18-wheres-next-101-release.md
@@ -1,6 +1,5 @@
 ---
 title: Where's Next? 1.0.1 Release
-published: 2011-08-18 21:03:58 +0000
 tags: wheresnext, app, project
 ---
 

--- a/_posts/2011-09-19-i-forked-quickdialog.md
+++ b/_posts/2011-09-19-i-forked-quickdialog.md
@@ -1,6 +1,5 @@
 ---
 title: I forked QuickDialog
-published: 2011-09-19 18:58:04 +0000
 tags: ios, quickdialog, github, projects
 ---
 

--- a/_posts/2011-09-21-configuring-gitosis-on-debian.md
+++ b/_posts/2011-09-21-configuring-gitosis-on-debian.md
@@ -1,6 +1,5 @@
 ---
 title: Configuring Gitosis on Debian
-published: 2011-09-21 22:45:32 +0000
 tags: git, gitosis, debian
 ---
 

--- a/_posts/2011-10-22-jacks-a-place-to-start-web-projects.md
+++ b/_posts/2011-10-22-jacks-a-place-to-start-web-projects.md
@@ -1,6 +1,5 @@
 ---
 title: "Jacks: A place to start web projects"
-published: 2011-10-22 21:37:54 +0000
 tags: web development, jacks, responsive design
 ---
 

--- a/_posts/2011-10-28-introducing-urbanscraper.md
+++ b/_posts/2011-10-28-introducing-urbanscraper.md
@@ -1,6 +1,5 @@
 ---
 title: Introducing UrbanScraper, and an Alfred Extension
-published: 2011-10-28 23:46:48 +0000
 tags: alfred, ruby, web-services, urban-dictionary, urbanscraper
 ---
 

--- a/_posts/2011-11-09-the-social-graph-identity.md
+++ b/_posts/2011-11-09-the-social-graph-identity.md
@@ -1,6 +1,5 @@
 ---
 title: "The Social Graph &amp; Thoughts on Identity"
-published: 2011-11-09 18:58:50 +0000
 tags: social-graph, social, link, identity
 ---
 

--- a/_posts/2011-11-26-drawing-primitives-with-quartz.md
+++ b/_posts/2011-11-26-drawing-primitives-with-quartz.md
@@ -1,6 +1,5 @@
 ---
 title: Drawing Primitives with Quartz
-published: 2011-11-26 23:13:28 +0000
 tags: drawing, graphics, quartz, iOS, macosx
 ---
 

--- a/_posts/2011-11-28-postgres-on-lion.md
+++ b/_posts/2011-11-28-postgres-on-lion.md
@@ -1,6 +1,5 @@
 ---
 title: Postgres on Lion
-published: 2011-11-28 23:07:46 +0000
 tags: lion, mac, osx, postgres, database
 ---
 

--- a/_posts/2012-01-06-christmas-books.md
+++ b/_posts/2012-01-06-christmas-books.md
@@ -1,6 +1,5 @@
 ---
 title: Christmas Books
-published: 2012-01-06 12:07:33 +0000
 tags: books, design, ios, coredata, mac, careers
 ---
 

--- a/_posts/2012-01-10-configuring-apache-and-php-on-lion.md
+++ b/_posts/2012-01-10-configuring-apache-and-php-on-lion.md
@@ -1,6 +1,5 @@
 ---
 title: Configuring Apache &amp; PHP on Lion
-published: 2012-01-10 15:03:29 +0000
 tags: lion, mac, apache, php
 ---
 

--- a/_posts/2012-01-15-pam-for-omniauth.md
+++ b/_posts/2012-01-15-pam-for-omniauth.md
@@ -1,6 +1,5 @@
 ---
 title: "PAM for OmniAuth: omniauth-pam"
-published: 2012-01-15 00:10:56 +0000
 tags: ruby, pam, linux, authentication, omniauth
 ---
 

--- a/_posts/2012-02-12-brussels-fosdem-2012.md
+++ b/_posts/2012-02-12-brussels-fosdem-2012.md
@@ -1,6 +1,5 @@
 ---
 title: Brussels &amp; FOSDEM 2012
-published: 2012-02-12 21:44:16 +0000
 tags: brussels, belgium, fosdem, conference
 ---
 

--- a/_posts/2012-02-13-mobile-security.md
+++ b/_posts/2012-02-13-mobile-security.md
@@ -1,6 +1,5 @@
 ---
 title: "Mobile Security: I Don't Even Know Where to Begin"
-published: 2012-02-13 20:01:09 +0000
 tags: security, mobile, ios
 ---
 

--- a/_posts/2012-02-26-review-hacking-and-securing-ios-applications.md
+++ b/_posts/2012-02-26-review-hacking-and-securing-ios-applications.md
@@ -1,6 +1,5 @@
 ---
 title: "Review: Hacking and Securing iOS Applications by Jonathan Zdziarski"
-published: 2012-02-26 22:47:50 +0000
 tags: review, book, ios, hacking, security
 ---
 

--- a/_posts/2012-03-12-git-workshop.md
+++ b/_posts/2012-03-12-git-workshop.md
@@ -1,6 +1,5 @@
 ---
 title: #digpen IV Git Workshop
-published: 2012-03-12 10:30:07 +0000
 tags: git, workshop, digpen
 ---
 

--- a/_posts/2012-03-29-orgcon-2012.md
+++ b/_posts/2012-03-29-orgcon-2012.md
@@ -1,6 +1,5 @@
 ---
 title: ORGCon 2012
-published: 2012-03-29 22:56:22 +0000
 tags: conference, open-rights-group, privacy, data, copyright
 ---
 

--- a/_posts/2012-05-06-nasa-space-apps-challenge-predict-the-sky.md
+++ b/_posts/2012-05-06-nasa-space-apps-challenge-predict-the-sky.md
@@ -1,6 +1,5 @@
 ---
 title: NASA Space Apps Challenge &amp; Predict the Sky
-published: 2012-05-06 11:15:16 +0000
 tags: nasa, space, space-apps-challenge, predict-the-sky
 ---
 

--- a/_posts/2012-05-29-bats-hacks-and-fieldwork.md
+++ b/_posts/2012-05-29-bats-hacks-and-fieldwork.md
@@ -1,6 +1,5 @@
 ---
 title: Bats, Hacks &amp; Fieldwork
-published: 2012-05-29 23:13:06 +0000
 tags: field-studies-council, hackday, bats, electronics, ios
 ---
 

--- a/_posts/2012-06-24-stuff-im-working-on-learning.md
+++ b/_posts/2012-06-24-stuff-im-working-on-learning.md
@@ -1,6 +1,5 @@
 ---
 title: Stuff I'm Working On &amp; Learning
-published: 2012-06-24 12:03:54 +0000
 tags: projects, learning, maths, ai, robotics, 3d-printing
 ---
 

--- a/_posts/2012-08-04-finishing-at-rokk-media.md
+++ b/_posts/2012-08-04-finishing-at-rokk-media.md
@@ -1,6 +1,5 @@
 ---
 title: Finishing at Rokk Media
-published: 2012-08-04 12:00:00 +0000
 tags: rokk-media, placement, university
 ---
 

--- a/_posts/2012-08-13-young-rewired-state-2012.md
+++ b/_posts/2012-08-13-young-rewired-state-2012.md
@@ -1,6 +1,5 @@
 ---
 title: Young Rewired State 2012
-published: 2012-08-13 12:00:00 +0000
 tags: programming, hackdays, young-rewired-state, rewired-state
 ---
 

--- a/_posts/2012-09-08-dconstruct-2012.md
+++ b/_posts/2012-09-08-dconstruct-2012.md
@@ -1,6 +1,5 @@
 ---
 title: dConstruct 2012
-published: 2012-09-08 12:00:00 +0000
 tags: conference, dconstruct
 ---
 

--- a/_posts/2012-09-20-nsconf-mini.md
+++ b/_posts/2012-09-20-nsconf-mini.md
@@ -1,6 +1,5 @@
 ---
 title: "NSConf Mini: Developers vs. Designers"
-published: 2012-09-20 12:00:00 +0000
 tags: nsconf, ideveloper, ios, conference
 ---
 

--- a/_posts/2012-10-17-blog-updates.md
+++ b/_posts/2012-10-17-blog-updates.md
@@ -1,6 +1,5 @@
 ---
 title: Blog Updates
-published: 2012-10-17 01:43:00 +0000
 tags: blog, personal
 ---
 

--- a/_posts/2013-03-24-digpen-vi.md
+++ b/_posts/2013-03-24-digpen-vi.md
@@ -1,6 +1,5 @@
 ---
 title: Digpen VI
-published: 2013-03-24 13:47:00 +0000
 tags: digpen, conference
 ---
 

--- a/_posts/2013-03-27-drawing-animating-shapes-matplotlib.md
+++ b/_posts/2013-03-27-drawing-animating-shapes-matplotlib.md
@@ -1,6 +1,5 @@
 ---
 title: Drawing and Animating Shapes with Matplotlib
-published: 2013-03-27 16:55:00 +0000
 tags: python, matplotlib, animation, drawing
 ---
 

--- a/_posts/2013-03-28-outputting-matplotlib-plots.md
+++ b/_posts/2013-03-28-outputting-matplotlib-plots.md
@@ -1,6 +1,5 @@
 ---
 title: Outputting Matplotlib Plots for the Web
-published: 2013-03-28 20:44:00 +0000
 tags: python, matplotlib, drawing
 ---
 

--- a/_posts/2013-03-30-beer-selection.md
+++ b/_posts/2013-03-30-beer-selection.md
@@ -1,6 +1,5 @@
 ---
 title: Beer Selection
-published: 2013-03-30 21:08:06 +0000
 tags: link
 ---
 

--- a/_posts/2013-03-31-updates-of-march.md
+++ b/_posts/2013-03-31-updates-of-march.md
@@ -1,6 +1,5 @@
 ---
 title: Updates of March
-published: 2013-03-31 21:43:00 +0000
 tags: blog, updates
 ---
 

--- a/_posts/2013-04-02-human-extinction.md
+++ b/_posts/2013-04-02-human-extinction.md
@@ -1,6 +1,5 @@
 ---
 title: On the Future of Humanity
-published: 2013-04-02 13:49:00 +0000
 tags: link
 ---
 

--- a/_posts/2013-04-02-long-journey-to-production.md
+++ b/_posts/2013-04-02-long-journey-to-production.md
@@ -1,6 +1,5 @@
 ---
 title: On the Long Journey to Production
-published: 2013-04-02 19:01:00 +0000
 tags: link
 ---
 

--- a/_posts/2013-04-04-test-environments-with-vagrant-and-chef.md
+++ b/_posts/2013-04-04-test-environments-with-vagrant-and-chef.md
@@ -1,6 +1,5 @@
 ---
 title: Test Environments with Vagrant and Chef
-published: 2013-04-04 00:46:00 +0000
 tags: vagrant, chef, programming
 ---
 

--- a/_posts/2013-04-05-expectations.md
+++ b/_posts/2013-04-05-expectations.md
@@ -1,6 +1,5 @@
 ---
 title: Expectations
-published: 2013-04-05 15:30:00 +0000
 tags: link
 ---
 

--- a/_posts/2013-04-08-ai-winter.md
+++ b/_posts/2013-04-08-ai-winter.md
@@ -1,6 +1,5 @@
 ---
 title: Are we approaching a new AI winter?
-published: 2013-04-08 16:35:06 +0000
 tags: link
 ---
 

--- a/_posts/2013-04-30-final-year-project-over.md
+++ b/_posts/2013-04-30-final-year-project-over.md
@@ -1,6 +1,5 @@
 ---
 title: Final Year Project is Over
-published: 2013-04-30 12:00:00 +0000
 tags: university, robotics
 ---
 

--- a/_posts/2013-05-02-paul-miller-returns.md
+++ b/_posts/2013-05-02-paul-miller-returns.md
@@ -1,6 +1,5 @@
 ---
 title: Paul Miller on his return to the Internet
-published: 2013-05-02 21:21:00 +0000
 tags: link
 ---
 

--- a/_posts/2013-05-06-bomber-cam.md
+++ b/_posts/2013-05-06-bomber-cam.md
@@ -1,6 +1,5 @@
 ---
 title: Building the Bomber Cam with 3D Printing and Scraps
-published: 2013-05-06 12:03:00 +0000
 tags: link
 ---
 

--- a/_posts/2013-05-06-maker-faire-2013.md
+++ b/_posts/2013-05-06-maker-faire-2013.md
@@ -1,6 +1,5 @@
 ---
 title: Maker Faire 2013
-published: 2013-05-06 19:00:00 +0000
 tags: maker-faire, newcastle, 3d-printing
 ---
 

--- a/_posts/2013-05-06-space-apps-challenge-2013.md
+++ b/_posts/2013-05-06-space-apps-challenge-2013.md
@@ -1,6 +1,5 @@
 ---
 title: Space Apps Challenge 2013
-published: 2013-05-06 18:00:00 +0000
 tags: space-apps-challenge, predictthesky
 ---
 

--- a/_posts/2013-05-06-way-of-the-megapode.md
+++ b/_posts/2013-05-06-way-of-the-megapode.md
@@ -1,6 +1,5 @@
 ---
 title: The Way of the Megapode
-published: 2013-05-06 10:57:00 +0000
 tags: link
 ---
 

--- a/_posts/2013-05-07-how-to-build-a-building.md
+++ b/_posts/2013-05-07-how-to-build-a-building.md
@@ -1,6 +1,5 @@
 ---
 title: "SparkFun: How to Build a Building"
-published: 2013-05-07 16:44:00 +0000
 tags: link
 ---
 

--- a/_posts/2013-05-21-default-narrative.md
+++ b/_posts/2013-05-21-default-narrative.md
@@ -1,6 +1,5 @@
 ---
 title: The Default Narative
-published: 2013-05-21 19:58:00 +0000
 tags: link
 ---
 

--- a/_posts/2013-05-21-downsides-of-live-music.md
+++ b/_posts/2013-05-21-downsides-of-live-music.md
@@ -1,6 +1,5 @@
 ---
 title: The downsides of live music
-published: 2013-05-21 20:04:00 +0000
 tags: link
 ---
 

--- a/_posts/2013-05-21-love-and-artificial-intelligence.md
+++ b/_posts/2013-05-21-love-and-artificial-intelligence.md
@@ -1,6 +1,5 @@
 ---
 title: "George Zarkadakis: Love and artificial intelligence"
-published: 2013-05-21 20:11:00 +0000
 tags: link
 ---
 

--- a/_posts/2013-05-21-personal-brands.md
+++ b/_posts/2013-05-21-personal-brands.md
@@ -1,6 +1,5 @@
 ---
 title: You should write about yourself more
-published: 2013-05-21 19:45:00 +0000
 tags: link
 ---
 

--- a/_posts/2013-05-21-wired-io.md
+++ b/_posts/2013-05-21-wired-io.md
@@ -1,6 +1,5 @@
 ---
 title: Wired writes something sensible about the Internet of Things
-published: 2013-05-21 19:51:00 +0000
 tags: link
 ---
 

--- a/_posts/2013-06-04-side-projects.md
+++ b/_posts/2013-06-04-side-projects.md
@@ -1,6 +1,5 @@
 ---
 title: Side Projects
-published: 2013-06-04 17:10:00 +0000
 tags: link
 ---
 

--- a/_posts/2013-06-06-android-ioio.md
+++ b/_posts/2013-06-06-android-ioio.md
@@ -1,6 +1,5 @@
 ---
 title: Experiments with Android, a IOIO board and Heart Rate Monitoring
-published: 2013-06-06 02:02:00 +0000
 tags: projects, android, ioio, heart-rate-monitor
 ---
 

--- a/_posts/2013-07-05-makers-of-things.md
+++ b/_posts/2013-07-05-makers-of-things.md
@@ -1,6 +1,5 @@
 ---
 title: The Makers of Things
-published: 2013-07-05 14:55:00 +0000
 tags: link
 ---
 

--- a/_posts/2013-07-06-interview-with-greg-brockman.md
+++ b/_posts/2013-07-06-interview-with-greg-brockman.md
@@ -1,6 +1,5 @@
 ---
 title: "How Stripe Buids Software: Interview with Greg Brockman"
-published: 2013-07-06 19:46:00 +0000
 tags: link
 ---
 

--- a/_posts/2013-07-06-mobile-app-market.md
+++ b/_posts/2013-07-06-mobile-app-market.md
@@ -1,6 +1,5 @@
 ---
 title: What's the mobile app market up to, then?
-published: 2013-07-06 19:06:00 +0000
 tags: link
 ---
 

--- a/_posts/2013-07-06-multiple-displays-opengl.md
+++ b/_posts/2013-07-06-multiple-displays-opengl.md
@@ -1,6 +1,5 @@
 ---
 title: Multiple Displays (and OpenGL)
-published: 2013-07-06 15:30:00 +0000
 tags: link
 ---
 

--- a/_posts/2013-07-07-dont-go-overboard-with-agile.md
+++ b/_posts/2013-07-07-dont-go-overboard-with-agile.md
@@ -1,6 +1,5 @@
 ---
 title: 7 Agile Best Practices that You Don't Need to Follow
-published: 2013-07-07 18:43:00 +0000
 tags: link
 ---
 

--- a/_posts/2013-08-01-debian-ubuntu-dynamic-motd.md
+++ b/_posts/2013-08-01-debian-ubuntu-dynamic-motd.md
@@ -1,6 +1,5 @@
 ---
 title: "Debian/Ubuntu: Dynamic MOTD"
-published: 2013-08-01 14:00:00 +0000
 tags: debian, ubuntu, sysadmin
 ---
 

--- a/_posts/2013-08-02-automated-backups-with-backup-and-rsyncnet.md
+++ b/_posts/2013-08-02-automated-backups-with-backup-and-rsyncnet.md
@@ -1,6 +1,5 @@
 ---
 title: Automated Backups with backup and Rsync.net
-published: 2013-08-02 17:50:00 +0000
 tags: sysadmin, backups, ruby
 ---
 

--- a/_posts/2013-08-08-moviesapi.md
+++ b/_posts/2013-08-08-moviesapi.md
@@ -1,6 +1,5 @@
 ---
 title: "moviesapi: A Simple API for UK Cinema Listings"
-published: 2013-08-08 13:40:00 +0000
 tags: ruby, api, rest, young-rewired-state
 ---
 

--- a/_posts/2013-08-12-ios-7-watershed-moment.md
+++ b/_posts/2013-08-12-ios-7-watershed-moment.md
@@ -1,6 +1,5 @@
 ---
 title: "iOS 7: Watershed Moment"
-published: 2013-08-12 13:24:00 +0000
 tags: link
 ---
 

--- a/_posts/2013-08-12-used-mac-minis.md
+++ b/_posts/2013-08-12-used-mac-minis.md
@@ -1,6 +1,5 @@
 ---
 title: The Market for Used Mac minis
-published: 2013-08-12 13:35:00 +0000
 tags: link
 ---
 

--- a/_posts/2013-08-13-tweetbot-mute-filters.md
+++ b/_posts/2013-08-13-tweetbot-mute-filters.md
@@ -1,6 +1,5 @@
 ---
 title: Tweetbot Mute Filters
-published: 2013-08-13 13:01:00 +0000
 tags: tweetbot, regex, twitter
 ---
 

--- a/_posts/2013-08-13-young-rewired-state-2013.md
+++ b/_posts/2013-08-13-young-rewired-state-2013.md
@@ -1,6 +1,5 @@
 ---
 title: Young Rewired State 2013
-published: 2013-08-13 09:45:00 +0000
 tags: young-rewired-state
 ---
 

--- a/_posts/2013-08-15-mocking-web-requests-vcr-minitest.md
+++ b/_posts/2013-08-15-mocking-web-requests-vcr-minitest.md
@@ -1,6 +1,5 @@
 ---
 title: Mocking Web Requests with VCR and MiniTest
-published: 2013-08-15 13:10:00 +0000
 tags: ruby, testing, minitest, moviesapi, screenscraping
 ---
 

--- a/_posts/2013-08-27-paste-cleanly.md
+++ b/_posts/2013-08-27-paste-cleanly.md
@@ -1,6 +1,5 @@
 ---
 title: "Alfred Workflow: Paste Cleanly"
-published: 2013-08-27 13:10:00 +0000
 tags: alfred, regex, ruby
 ---
 

--- a/_posts/2013-08-28-switching-season-report-2013.md
+++ b/_posts/2013-08-28-switching-season-report-2013.md
@@ -1,6 +1,5 @@
 ---
 title: Switching Season Report, 2013 Edition
-published: 2013-08-28 07:39:00 +0000
 tags: link
 ---
 

--- a/_posts/2014-01-07-annual-review-2013.md
+++ b/_posts/2014-01-07-annual-review-2013.md
@@ -1,6 +1,5 @@
 ---
 title: Annual Review 2013
-published: 2014-01-07 16:19:00 +0000
 tags: annual-review, life, projects
 ---
 

--- a/_posts/2014-01-08-ruby-subprocesses-with-stdout-stderr-streams.md
+++ b/_posts/2014-01-08-ruby-subprocesses-with-stdout-stderr-streams.md
@@ -1,6 +1,5 @@
 ---
 title: Ruby Subprocesses with stdout and stderr Streams
-published: 2014-01-08 16:03:00 +0000
 tags: ruby, posix, boxes
 ---
 

--- a/_posts/2014-08-18-debugging-sentestingkit-to-xctest-linker-errors.md
+++ b/_posts/2014-08-18-debugging-sentestingkit-to-xctest-linker-errors.md
@@ -1,6 +1,5 @@
 ---
 title: Debugging SenTestingKit to XCTest Linker Errors in Upgraded Xcode Projects
-published: 2014-08-18 18:00:00 +0000
 tags: xcode, testing, sentestingkit, xctest, ios
 ---
 

--- a/_posts/2014-08-20-custom-pandoc-options-hakyll-4.md
+++ b/_posts/2014-08-20-custom-pandoc-options-hakyll-4.md
@@ -1,6 +1,5 @@
 ---
 title: Custom Pandoc Options with Hakyll 4
-published: 2014-08-20 09:37:00 +0000
 tags: pandoc, hakyll, haskell
 ---
 

--- a/_posts/2014-08-20-site-v4.md
+++ b/_posts/2014-08-20-site-v4.md
@@ -1,6 +1,5 @@
 ---
 title: Site v4
-published: 2014-08-20 11:42:00 +0000
 tags: site, release
 ---
 

--- a/_posts/2014-10-12-reserve-caching-with-expire-keys-redis.md
+++ b/_posts/2014-10-12-reserve-caching-with-expire-keys-redis.md
@@ -1,6 +1,5 @@
 ---
 title: "Reserve: Caching with Expiring Keys and Redis"
-published: 2014-10-12 00:00:00 +0000
 tags: redis, ruby, caching
 ---
 

--- a/_posts/2014-11-29-structuring-sinatra-applications.md
+++ b/_posts/2014-11-29-structuring-sinatra-applications.md
@@ -1,6 +1,5 @@
 ---
 title: Structuring Sinatra Applications
-published: 2014-11-29 17:51:40 +0000
 tags: sinatra, ruby
 ---
 

--- a/_posts/2014-12-15-postmark-with-sinatra.md
+++ b/_posts/2014-12-15-postmark-with-sinatra.md
@@ -1,6 +1,5 @@
 ---
 title: Using Postmark with Sinatra
-published: 2014-12-15 15:18:01 +0000
 tags: ruby, sinatra, mail, postmark
 ---
 

--- a/_posts/2015-03-11-conditionally-chaining-activerecord-queries.md
+++ b/_posts/2015-03-11-conditionally-chaining-activerecord-queries.md
@@ -1,6 +1,5 @@
 ---
 title: Conditionally Chaining ActiveRecord Queries
-published: 2015-03-11 09:22:51 +0000
 tags: ruby, rails, activerecord
 ---
 

--- a/_posts/2015-03-28-transparent-proxy-virtual-machines-mitmproxy.md
+++ b/_posts/2015-03-28-transparent-proxy-virtual-machines-mitmproxy.md
@@ -1,6 +1,5 @@
 ---
 title: Setting up Transparent Proxying VMs for mitmproxy
-published: 2015-03-28 22:29:31 +0000
 tags: vmware, transparent-proxy, mitmproxy
 ---
 

--- a/_posts/2015-04-14-static-sites-with-rack-sass.md
+++ b/_posts/2015-04-14-static-sites-with-rack-sass.md
@@ -1,6 +1,5 @@
 ---
 title: Static Sites with Rack and Sass
-published: 2015-04-14 11:56:52 +0000
 tags: ruby, rack, sass
 ---
 


### PR DESCRIPTION
This isn't needed, as Jekyll will take the published date from the post file name but most importantly they're formatted incorrectly in most cases.

    find _posts -type f -name "*.md" -exec sed -i '' '/published\:/d' {} \;