### PR TITLE
Fix duplicated commas in tags

### DIFF
--- a/_posts/2009-05-08-ubuntu-on-sdcard.md
+++ b/_posts/2009-05-08-ubuntu-on-sdcard.md
@@ -1,6 +1,6 @@
 ---
 title: Installing Ubuntu 9.04 on an SD card
-tags: ubuntu, sd-card
+tags: ubuntu sd-card
 ---
 
 **Note: This article is quite old. It probably doesn't apply anymore. Your

--- a/_posts/2009-05-18-introduction-to-sqlite-2-with-php-5.md
+++ b/_posts/2009-05-18-introduction-to-sqlite-2-with-php-5.md
@@ -1,6 +1,6 @@
 ---
 title: Introduction to SQLite 2 with PHP 5
-tags: php, sqlite
+tags: php sqlite
 ---
 
 Where a full <acronym title="Relational Database Management System">RDBMS</acronym> is unnecessary, [SQLite](http://www.sqlite.org/) provides the perfect stand in. However, most articles are based around the Object-Orientated way of dealing with SQLite in PHP. This article provides an explanation of how to use it procedurally.

--- a/_posts/2009-06-24-ssh-banner-debian.md
+++ b/_posts/2009-06-24-ssh-banner-debian.md
@@ -1,6 +1,6 @@
 ---
 title: Configuring an SSH banner on Debian
-tags: debian, ssh
+tags: debian ssh
 ---
 
 _**Note:** I've since come up with something much better, which dynamically generates

--- a/_posts/2009-06-26-configuring-sudo-on-debian.md
+++ b/_posts/2009-06-26-configuring-sudo-on-debian.md
@@ -1,6 +1,6 @@
 ---
 title: Configuring Sudo on Debian
-tags: debian, sudo, security
+tags: debian sudo security
 ---
 
 Setting up sudo on Debian can seem daunting at first, but the process is really quite simple.

--- a/_posts/2009-09-11-public-key-auth-screencast.md
+++ b/_posts/2009-09-11-public-key-auth-screencast.md
@@ -1,6 +1,6 @@
 ---
 title: Public Key Auth Screencast
-tags: ssh, security, screencast
+tags: ssh security screencast
 ---
 
 After a request by <a href="http://twitter.com/nickcharlton/status/3884874880">Peter Upfold</a> on Twitter for ideas for a screencast, I suggested he do something on Public Key Authentication. My wish was made true as he made it up yesterday. 

--- a/_posts/2009-09-18-ssh-public-key-screencast-notes.md
+++ b/_posts/2009-09-18-ssh-public-key-screencast-notes.md
@@ -1,6 +1,6 @@
 ---
 title: SSH Public Key Screencast Notes
-tags: ssh, security, screencast
+tags: ssh security screencast
 ---
 
 _These are just a few quick notes to accompany [Peter Upfold's screencast](http://vimeo.com/6523718). If you haven't ready I would suggest you give it a watch before following this rather brief notes_

--- a/_posts/2009-10-05-jekyll-and-github.md
+++ b/_posts/2009-10-05-jekyll-and-github.md
@@ -1,6 +1,6 @@
 ---
 title: Jekyll and GitHub
-tags: jekyll, github, blogging
+tags: jekyll github blogging
 ---
 
 After quite a bit of work, I have finally moved over to using GitHub pages, Jekyll and Markdown to power [nickcharlton.net](http://nickcharlton.net "nickcharlton.net").

--- a/_posts/2009-11-03-ideas-and-university.md
+++ b/_posts/2009-11-03-ideas-and-university.md
@@ -1,6 +1,6 @@
 ---
 title: Ideas and University
-tags: ideas, university, thoughts
+tags: ideas university thoughts
 ---
 
 It's been a while since I've written down a set of thoughts. Most of which occurred before I started University. What I do want to ponder here I will come to in a moment, but now I've been at University for nearly 4 months - I'm trailing on to the end of the first term. 

--- a/_posts/2010-04-14-sqlite-with-csharp.md
+++ b/_posts/2010-04-14-sqlite-with-csharp.md
@@ -1,6 +1,6 @@
 ---
 title: SQLite, ADO.NET & CSharp
-tags: dotnet, csharp, sqlite
+tags: dotnet csharp sqlite
 ---
 
 ### Introduction

--- a/_posts/2010-05-30-new-project.md
+++ b/_posts/2010-05-30-new-project.md
@@ -1,6 +1,6 @@
 ---
 title: New Project
-tags: blog, sinba
+tags: blog sinba
 ---
 
 After a few weeks of work, this is "Version 4", of my blog. I have a slightly different design, and a different focus which should represent changes in me.

--- a/_posts/2010-07-10-css3-bundle.md
+++ b/_posts/2010-07-10-css3-bundle.md
@@ -1,6 +1,6 @@
 ---
 title: CSS3 Bundle
-tags: css3, textmate, bundle, projects
+tags: css3 textmate bundle projects
 ---
 
 The default CSS bundle in TextMate doesn't include any of the new features of CSS3. I'd tried other TextMate CSS3 plugins, but in general they didn't cover enough and seemed unmaintained.

--- a/_posts/2010-09-17-on-long-way-down.md
+++ b/_posts/2010-09-17-on-long-way-down.md
@@ -1,6 +1,6 @@
 ---
 title: On Long Way Down
-tags: book, adventure, long-way-down
+tags: book adventure long-way-down
 ---
 
 [Long Way Down](http://www.amazon.co.uk/gp/product/0751538957?ie=UTF8&tag=nisbl-21&linkCode=as2&camp=1634&creative=19450&creativeASIN=0751538957) was a good series. Back in 2007, Ewan McGregor and Charley Boorman set out on a motorcycle trip from John O'Groats to Cape Town. I just finished reading the accompanying book, that's been on my book shelf for quite a while.

--- a/_posts/2010-09-29-bcs-lecture-series-apple-the-birth-of-a-third-platform.md
+++ b/_posts/2010-09-29-bcs-lecture-series-apple-the-birth-of-a-third-platform.md
@@ -1,6 +1,6 @@
 ---
 title: "BCS Lecture Series: Apple (The Birth of a Third Platform)"
-tags: lecture, apple, mobile
+tags: lecture apple mobile
 ---
 
 Yesterday evening, [Chris Hunt](http://twitter.com/thisisthechris) and myself went along to a talk at the BCS from Apple, entitled "The Birth of a Third Platform, Mobile Computing in HE". Overall, it was a good talk, even with the heavy Apple marketing angle.

--- a/_posts/2010-11-10-bcs-lecture-series-physical-security-in-it.md
+++ b/_posts/2010-11-10-bcs-lecture-series-physical-security-in-it.md
@@ -1,6 +1,6 @@
 ---
 title: "BCS Lecture Series: Physical Security in IT"
-tags: bcs, lecture, infosec, physical security
+tags: bcs lecture infosec physical security
 ---
 
 This month's lecture was delivered by [Thomas Hackner](http://www.hackner-security.com/), from the [University of Applied Sciences, Hagenberg, Upper Austria](http://www.fh-ooe.at/en/). 

--- a/_posts/2010-12-26-progcomp-a-programming-competitions-blog.md
+++ b/_posts/2010-12-26-progcomp-a-programming-competitions-blog.md
@@ -1,6 +1,6 @@
 ---
 title: "ProgComp: A Programming Competitions Blog"
-tags: projects, progcomp, programming
+tags: projects progcomp programming
 ---
 
 Last week I launched [ProgComp](http://progcomp.tumblr.com/). The idea is to produce a continuing flow of curated programming competitions.

--- a/_posts/2011-02-06-guide-to-sax-in-java.md
+++ b/_posts/2011-02-06-guide-to-sax-in-java.md
@@ -1,6 +1,6 @@
 ---
 title: An Ultra-simple Guide to Reading XML in Java, using SAX
-tags: java, xml, sax
+tags: java xml sax
 ---
 
 For the piece of work I have been dealing with recently, I was required to implement persistence using XML in Java. I figured this would be simple. Java and XML are used all the time, right? Should be easy.

--- a/_posts/2011-02-08-termisoc-hack-weekend-2011.md
+++ b/_posts/2011-02-08-termisoc-hack-weekend-2011.md
@@ -1,6 +1,6 @@
 ---
 title: TermiSoc Hack Weekend 2011
-tags: termisoc, hack-weekend, python, app-engine, mobile, location, arduino
+tags: termisoc hack-weekend python app-engine mobile location arduino
 ---
 
 _I intend for this post to hold all of the presentations and sessions that we've hosted for the TermiSoc Hack Weekend 2011. This post will expand in the future as more content is covered._

--- a/_posts/2011-03-02-using-rubyoci8-on-ubuntudebian.md
+++ b/_posts/2011-03-02-using-rubyoci8-on-ubuntudebian.md
@@ -1,6 +1,6 @@
 ---
 title: Using ruby-oci8 on Ubuntu/Debian
-tags: ruby, oracle, ruby-oci8, ubuntu, debian
+tags: ruby oracle ruby-oci8 ubuntu debian
 ---
 
 With this year's integrating project, we were required to write a web service to integrate Android with the University's Oracle server. After asking to use Ruby (and succeeding), I was then left with the obstacle of hooking up to the Oracle database. These a few notes on getting this working.

--- a/_posts/2011-03-07-the-digital-peninsulas-first-web-unconference.md
+++ b/_posts/2011-03-07-the-digital-peninsulas-first-web-unconference.md
@@ -1,6 +1,6 @@
 ---
 title: The Digital Peninsula's First Web Unconference
-tags: digpen, termisoc, unconference, digital peninsula
+tags: digpen termisoc unconference digital peninsula
 ---
 
 On Saturday I gave a quick talk about [TermiSoc](http://termisoc.org/) at the [Unconference](http://medworm.eventbrite.com/) in the University. [Frankie](https://twitter.com/#!/frankiedolan) put together a great event, with a really good turn out, with more than 80 people showing up, from down in Cornwall, all the way up to Bristol.

--- a/_posts/2011-03-22-review-arduino-cookbook-by-michael-margolis.md
+++ b/_posts/2011-03-22-review-arduino-cookbook-by-michael-margolis.md
@@ -1,6 +1,6 @@
 ---
 title: "Review: Arduino Cookbook by Michael Margolis"
-tags: review, arduino
+tags: review arduino
 ---
 
 For a while, I've wanted to play around with the [Arduino](http://arduino.cc/); the open source embedded hardware that's stuck it's claws into everything from the arts, to personal projects and much more. Then, [Arduino Cookbook](http://oreilly.com/catalog/9780596802486/) came up on the O'Reilly Blogger Review Program, and I couldn't say no to having a pushed look into it.

--- a/_posts/2011-05-11-building-custom-android-listviews.md
+++ b/_posts/2011-05-11-building-custom-android-listviews.md
@@ -1,6 +1,6 @@
 ---
 title: Building Custom Android ListViews
-tags: android, listview, java
+tags: android listview java
 ---
 
 The documentation for Android's `ListView`'s is a little sparse. The examples around on the web are also not too great. This article intends to be the one I was searching for in trying to understand how to display some more advanced data, and deal with events.

--- a/_posts/2011-05-15-digital-peninsula-unconference-ii-exeter.md
+++ b/_posts/2011-05-15-digital-peninsula-unconference-ii-exeter.md
@@ -1,6 +1,6 @@
 ---
 title: Digital Peninsula Unconference II, Exeter
-tags: digpen, unconference, digital peninsula
+tags: digpen unconference digital peninsula
 ---
 
 On Saturday, the second version of the [Digital Peninsula Unconference](http://lanyrd.com/2011/digpenII/) was hosted in Exeter, at the Phoenix. After being [volunteered to take some photographs](http://twitter.com/#!/teddilybear/status/68722214702301185), I spent much of the event running about taking them (that's the flaw in having only a 50mm lens available to you). I've posted them on Flickr, but below are a few of the ones I liked best.

--- a/_posts/2011-06-12-digital-peninsula-unconference-iii-falmouth.md
+++ b/_posts/2011-06-12-digital-peninsula-unconference-iii-falmouth.md
@@ -1,6 +1,6 @@
 ---
 title: Digital Peninsula Unconference III, Falmouth
-tags: photos, digpen, falmouth, unconference
+tags: photos digpen falmouth unconference
 ---
 
 Yesterday was the third iteration of the Digital Peninsula Unconference, at [University College Falmouth, Tremough](http://www.falmouth.ac.uk/).

--- a/_posts/2011-06-13-thoughts-on-the-uop-intellectual-property-agreement.md
+++ b/_posts/2011-06-13-thoughts-on-the-uop-intellectual-property-agreement.md
@@ -1,6 +1,6 @@
 ---
 title: Thoughts on the UoP Intellectual Property Agreement
-tags: uop, ip
+tags: uop ip
 ---
 
 Today, the [University announced that they had entered into an Intellectual Property agreement](http://www.plymouth.ac.uk/pages/view.asp?page=36193). For 10 years. I think this is a terrible idea.

--- a/_posts/2011-07-26-starting-at-rokk-media.md
+++ b/_posts/2011-07-26-starting-at-rokk-media.md
@@ -1,6 +1,6 @@
 ---
 title: Starting at Rokk Media
-tags: rokk-media, placement, iOS
+tags: rokk-media placement iOS
 ---
 
 Today marks the start of the second week of my placement (actually, the second day of the second week); doing iOS Development at Rokk Media on the outskirts of Exeter.

--- a/_posts/2011-08-12-wheres-next-now-in-the-app-store.md
+++ b/_posts/2011-08-12-wheres-next-now-in-the-app-store.md
@@ -1,6 +1,6 @@
 ---
 title: Where's Next? Now In the App Store.
-tags: app, iphone, projects
+tags: app iphone projects
 ---
 
 After many, many months of development, my first iOS project is now in the App Store. It's a utility app for sorting places into the most efficient way to get there, from the site:

--- a/_posts/2011-08-18-wheres-next-101-release.md
+++ b/_posts/2011-08-18-wheres-next-101-release.md
@@ -1,6 +1,6 @@
 ---
 title: Where's Next? 1.0.1 Release
-tags: wheresnext, app, project
+tags: wheresnext app project
 ---
 
 After a bit of an issue with the original launch, _Where's Next?_ 1.0.1 has now been approved and is [in the App Store](http://itunes.apple.com/gb/app/wheres-next/id454450198?mt=8).

--- a/_posts/2011-09-19-i-forked-quickdialog.md
+++ b/_posts/2011-09-19-i-forked-quickdialog.md
@@ -1,6 +1,6 @@
 ---
 title: I forked QuickDialog
-tags: ios, quickdialog, github, projects
+tags: ios quickdialog github projects
 ---
 
 A couple of weeks ago, [Eduardo Scoz (ESCOZ, Inc)](http://escoz.com/) released [QuickDialog](http://escoz.com/quickdialog-released/), a rather nice way of producing UITableView based dialog controls on iOS.

--- a/_posts/2011-09-21-configuring-gitosis-on-debian.md
+++ b/_posts/2011-09-21-configuring-gitosis-on-debian.md
@@ -1,6 +1,6 @@
 ---
 title: Configuring Gitosis on Debian
-tags: git, gitosis, debian
+tags: git gitosis debian
 ---
 
 Gitosis is a tool for easing the hosting of Git repositories. For pushing to remote [servers], Git uses SSH. Which is great. But, what if you don't want those users to have shell accounts, and you want to be able to control who has access to repositories? Well, that's what Gitosis does.

--- a/_posts/2011-10-22-jacks-a-place-to-start-web-projects.md
+++ b/_posts/2011-10-22-jacks-a-place-to-start-web-projects.md
@@ -1,6 +1,6 @@
 ---
 title: "Jacks: A place to start web projects"
-tags: web development, jacks, responsive design
+tags: web development jacks responsive design
 ---
 
 A couple of weeks ago, I started a project which intended to pull together all of the stuff that I had learnt about responsive design. I also wanted to have a generic starting point for web projects. I came up with Jacks, a simple web "framework" which does exactly that.

--- a/_posts/2011-10-28-introducing-urbanscraper.md
+++ b/_posts/2011-10-28-introducing-urbanscraper.md
@@ -1,6 +1,6 @@
 ---
 title: Introducing UrbanScraper, and an Alfred Extension
-tags: alfred, ruby, web-services, urban-dictionary, urbanscraper
+tags: alfred ruby web-services urban-dictionary urbanscraper
 ---
 
 Over the last two evenings, I've been working on a little toy. Well, two. The first one is a web service for getting definitions from [Urban Dictionary](http://urbandictionary.com) and the other is an Alfred Extension to allow you to get those definitions using your keyboard.

--- a/_posts/2011-11-09-the-social-graph-identity.md
+++ b/_posts/2011-11-09-the-social-graph-identity.md
@@ -1,6 +1,6 @@
 ---
 title: "The Social Graph &amp; Thoughts on Identity"
-tags: social-graph, social, link, identity
+tags: social-graph social link identity
 ---
 
 [Maciej Ceglowski on "The Social Graph is Neither"](http://blog.pinboard.in/2011/11/the_social_graph_is_neither/)…

--- a/_posts/2011-11-26-drawing-primitives-with-quartz.md
+++ b/_posts/2011-11-26-drawing-primitives-with-quartz.md
@@ -1,6 +1,6 @@
 ---
 title: Drawing Primitives with Quartz
-tags: drawing, graphics, quartz, iOS, macosx
+tags: drawing graphics quartz iOS macosx
 ---
 
 I've always found drawing graphics complicated. Not that because maths is involved (that's the good bit), but finding simple examples to work out what the hell is going on. Usually, the calls required are a little different, and required to ensure something actually gets drawn &mdash; Quartz is no different. This intends to serve as a few notes on using the basics of QuartzCore, the drawing tools present in iOS and on Mac OS X. 

--- a/_posts/2011-11-28-postgres-on-lion.md
+++ b/_posts/2011-11-28-postgres-on-lion.md
@@ -1,6 +1,6 @@
 ---
 title: Postgres on Lion
-tags: lion, mac, osx, postgres, database
+tags: lion mac osx postgres database
 ---
 
 I've recently been picking up [PostgreSQL](http://www.postgresql.org/). It's very nice. Unfortunately, I had a few issues with it and Lion. Lion Server now uses Postgres as its default database (replacing MySQL), and consequently it looks like Apple included a bunch of tools in standard Lion, too. 

--- a/_posts/2012-01-06-christmas-books.md
+++ b/_posts/2012-01-06-christmas-books.md
@@ -1,6 +1,6 @@
 ---
 title: Christmas Books
-tags: books, design, ios, coredata, mac, careers
+tags: books design ios coredata mac careers
 ---
 
 I read quite a few things over Christmas, here's some notes on a few of them:

--- a/_posts/2012-01-10-configuring-apache-and-php-on-lion.md
+++ b/_posts/2012-01-10-configuring-apache-and-php-on-lion.md
@@ -1,6 +1,6 @@
 ---
 title: Configuring Apache &amp; PHP on Lion
-tags: lion, mac, apache, php
+tags: lion mac apache php
 ---
 
 There are too many terrible articles on configuring Apache and PHP on the Mac, especially for Lion. Even worse are the suggestions of using other versions, or overly complex configuration methods. 

--- a/_posts/2012-01-15-pam-for-omniauth.md
+++ b/_posts/2012-01-15-pam-for-omniauth.md
@@ -1,6 +1,6 @@
 ---
 title: "PAM for OmniAuth: omniauth-pam"
-tags: ruby, pam, linux, authentication, omniauth
+tags: ruby pam linux authentication omniauth
 ---
 
 I have a couple of small web applications that I have built for myself (wiki, system monitoring, etc.) There didn't seem much point in adding a database for authentication, so I put together a strategy for using [PAM](http://en.wikipedia.org/wiki/Linux_PAM) and [OmniAuth](https://github.com/intridea/omniauth/).

--- a/_posts/2012-02-12-brussels-fosdem-2012.md
+++ b/_posts/2012-02-12-brussels-fosdem-2012.md
@@ -1,6 +1,6 @@
 ---
 title: Brussels &amp; FOSDEM 2012
-tags: brussels, belgium, fosdem, conference
+tags: brussels belgium fosdem conference
 ---
 
 Last weekend, I was in Brussels for [FOSDEM](http://fosdem.org/2012/). It was an excellent weekend. I didn't go too that many sessions at FOSDEM, but the ones I did go to were pretty good and have pushed me into finding out a few more things in detail.

--- a/_posts/2012-02-13-mobile-security.md
+++ b/_posts/2012-02-13-mobile-security.md
@@ -1,6 +1,6 @@
 ---
 title: "Mobile Security: I Don't Even Know Where to Begin"
-tags: security, mobile, ios
+tags: security mobile ios
 ---
 
 With the [recent Path debacle](http://mclov.in/2012/02/08/path-uploads-your-entire-address-book-to-their-servers.html), the security and privacy practices of various mobile application developers has come to light. Generally, this has focused around the use of Address Book data; here, developers are balancing violating individual privacy with easier connections - the metric of importance for such apps. On its own, this is fine — providing you have the user’s permission — the issue is in how developers are going about implementing it.

--- a/_posts/2012-02-26-review-hacking-and-securing-ios-applications.md
+++ b/_posts/2012-02-26-review-hacking-and-securing-ios-applications.md
@@ -1,6 +1,6 @@
 ---
 title: "Review: Hacking and Securing iOS Applications by Jonathan Zdziarski"
-tags: review, book, ios, hacking, security
+tags: review book ios hacking security
 ---
 
 I started this just after the [Path fiasco](http://nickcharlton.net/post/mobile-security). It seemed timely to brush up on my security knowledge, especially for iOS intricacies, recommended practices and understanding obvious flaws. At the same time, O'Reilly had published ["Hacking and Securing iOS Applications" by Jonathan Zdziarski](http://shop.oreilly.com/product/0636920023234.do), so I got a copy. This book provides exactly what I wanted; it's a great next-step if you've been developing for iOS or the Mac for a while. Fortunately it assumes that, which allows the book to quickly jump into examples and solutions. 

--- a/_posts/2012-03-12-git-workshop.md
+++ b/_posts/2012-03-12-git-workshop.md
@@ -1,6 +1,6 @@
 ---
 title: #digpen IV Git Workshop
-tags: git, workshop, digpen
+tags: git workshop digpen
 ---
 
 On Saturday, [Chris Hunt](http://thisisthechris.co.uk/) and I gave a workshop on Git at Digpen IV in Exeter. It seemed to go rather well. 

--- a/_posts/2012-03-29-orgcon-2012.md
+++ b/_posts/2012-03-29-orgcon-2012.md
@@ -1,6 +1,6 @@
 ---
 title: ORGCon 2012
-tags: conference, open-rights-group, privacy, data, copyright
+tags: conference open-rights-group privacy data copyright
 ---
 
 On Saturday, I was at the [Open Rights Group](http://www.openrightsgroup.org/) Conference at the University of Westminster in London. It was a very good day, full of interesting talks from the likes of Cory Doctorow, Wendy Seltzer and Laurance Lessig. It was the first time I've seen these talk in person (Lessig was notably impressive - especially with his slides.) Below are some of the notes I made.

--- a/_posts/2012-05-06-nasa-space-apps-challenge-predict-the-sky.md
+++ b/_posts/2012-05-06-nasa-space-apps-challenge-predict-the-sky.md
@@ -1,6 +1,6 @@
 ---
 title: NASA Space Apps Challenge &amp; Predict the Sky
-tags: nasa, space, space-apps-challenge, predict-the-sky
+tags: nasa space space-apps-challenge predict-the-sky
 ---
 
 Two weekends ago I was at the [Met Office](http://metoffice.gov.uk/) for the [NASA International Space Apps Challenge](http://spaceappschallenge.org/). It was quite a fantastic weekend. Four or so teams of people worked on a set of preset challenges (suggested by the leaders of those teams in the weeks running up to the event) and the rest of us congregated around the group we were most interested in.

--- a/_posts/2012-05-29-bats-hacks-and-fieldwork.md
+++ b/_posts/2012-05-29-bats-hacks-and-fieldwork.md
@@ -1,6 +1,6 @@
 ---
 title: Bats, Hacks &amp; Fieldwork
-tags: field-studies-council, hackday, bats, electronics, ios
+tags: field-studies-council hackday bats electronics ios
 ---
 
 Two weekends ago, I was in Slapton at the [Field Studies Council](http://field-studies-council.org/) for their first hack day. It aimed to bring together both people in education and those in technology and see what could be done when you bashed their two heads together. And it was bloody good.

--- a/_posts/2012-06-24-stuff-im-working-on-learning.md
+++ b/_posts/2012-06-24-stuff-im-working-on-learning.md
@@ -1,6 +1,6 @@
 ---
 title: Stuff I'm Working On &amp; Learning
-tags: projects, learning, maths, ai, robotics, 3d-printing
+tags: projects learning maths ai robotics 3d-printing
 ---
 
 This morning, [Rafe](http://rc3.org/) [posted about the stuff he'd like to be learning](http://rc3.org/2012/06/23/stuff-i-needwant-to-spend-time-learning/). So, I thought that was a nice way to remind myself all the stuff I'm currently working on and the stuff I'm attempting to learn, in various states of completion:

--- a/_posts/2012-08-04-finishing-at-rokk-media.md
+++ b/_posts/2012-08-04-finishing-at-rokk-media.md
@@ -1,6 +1,6 @@
 ---
 title: Finishing at Rokk Media
-tags: rokk-media, placement, university
+tags: rokk-media placement university
 ---
 
 And, so, that is the end of my placement. The conclusion of a year of working

--- a/_posts/2012-08-13-young-rewired-state-2012.md
+++ b/_posts/2012-08-13-young-rewired-state-2012.md
@@ -1,6 +1,6 @@
 ---
 title: Young Rewired State 2012
-tags: programming, hackdays, young-rewired-state, rewired-state
+tags: programming hackdays young-rewired-state rewired-state
 ---
 
 Last week, I had the privilege of helping mentor seven young people as part of

--- a/_posts/2012-09-08-dconstruct-2012.md
+++ b/_posts/2012-09-08-dconstruct-2012.md
@@ -1,6 +1,6 @@
 ---
 title: dConstruct 2012
-tags: conference, dconstruct
+tags: conference dconstruct
 ---
 
 Yesterday was [dConstruct](http://2012.dconstruct.org/). I went to dConstruct 

--- a/_posts/2012-09-20-nsconf-mini.md
+++ b/_posts/2012-09-20-nsconf-mini.md
@@ -1,6 +1,6 @@
 ---
 title: "NSConf Mini: Developers vs. Designers"
-tags: nsconf, ideveloper, ios, conference
+tags: nsconf ideveloper ios conference
 ---
 
 On Monday, it was NSConf Mini: "Developers vs. Designers". This was a 1-day

--- a/_posts/2012-10-17-blog-updates.md
+++ b/_posts/2012-10-17-blog-updates.md
@@ -1,6 +1,6 @@
 ---
 title: Blog Updates
-tags: blog, personal
+tags: blog personal
 ---
 
 For a project several weeks in the making, I've just pushed up the changes to

--- a/_posts/2013-03-24-digpen-vi.md
+++ b/_posts/2013-03-24-digpen-vi.md
@@ -1,6 +1,6 @@
 ---
 title: Digpen VI
-tags: digpen, conference
+tags: digpen conference
 ---
 
 Yesterday was Digpen VI, down at the Eden Project in Cornwall. It was a wonderful

--- a/_posts/2013-03-27-drawing-animating-shapes-matplotlib.md
+++ b/_posts/2013-03-27-drawing-animating-shapes-matplotlib.md
@@ -1,6 +1,6 @@
 ---
 title: Drawing and Animating Shapes with Matplotlib
-tags: python, matplotlib, animation, drawing
+tags: python matplotlib animation drawing
 ---
 
 As well a being the best Python package for drawing plots, [Matplotlib][] also has 

--- a/_posts/2013-03-28-outputting-matplotlib-plots.md
+++ b/_posts/2013-03-28-outputting-matplotlib-plots.md
@@ -1,6 +1,6 @@
 ---
 title: Outputting Matplotlib Plots for the Web
-tags: python, matplotlib, drawing
+tags: python matplotlib drawing
 ---
 
 For the past few days, I've been working with Matplotlib and collecting together a 

--- a/_posts/2013-03-31-updates-of-march.md
+++ b/_posts/2013-03-31-updates-of-march.md
@@ -1,6 +1,6 @@
 ---
 title: Updates of March
-tags: blog, updates
+tags: blog updates
 ---
 
 In which I document some changes I made around here…

--- a/_posts/2013-04-04-test-environments-with-vagrant-and-chef.md
+++ b/_posts/2013-04-04-test-environments-with-vagrant-and-chef.md
@@ -1,6 +1,6 @@
 ---
 title: Test Environments with Vagrant and Chef
-tags: vagrant, chef, programming
+tags: vagrant chef programming
 ---
 
 I recently completed a project for an assignment which had a mess of dependencies.

--- a/_posts/2013-04-30-final-year-project-over.md
+++ b/_posts/2013-04-30-final-year-project-over.md
@@ -1,6 +1,6 @@
 ---
 title: Final Year Project is Over
-tags: university, robotics
+tags: university robotics
 ---
 
 And so, my final year project was handed in. This marks the tail end of my degree

--- a/_posts/2013-05-06-maker-faire-2013.md
+++ b/_posts/2013-05-06-maker-faire-2013.md
@@ -1,6 +1,6 @@
 ---
 title: Maker Faire 2013
-tags: maker-faire, newcastle, 3d-printing
+tags: maker-faire newcastle 3d-printing
 ---
 
 Last weekend was [Maker Faire UK][], up in Newcastle. [Stewart][], [Dan][] and I

--- a/_posts/2013-05-06-space-apps-challenge-2013.md
+++ b/_posts/2013-05-06-space-apps-challenge-2013.md
@@ -1,6 +1,6 @@
 ---
 title: Space Apps Challenge 2013
-tags: space-apps-challenge, predictthesky
+tags: space-apps-challenge predictthesky
 ---
 
 A few weekends ago was the second [NASA Space Apps Challenge][], a hack day centred

--- a/_posts/2013-06-06-android-ioio.md
+++ b/_posts/2013-06-06-android-ioio.md
@@ -1,6 +1,6 @@
 ---
 title: Experiments with Android, a IOIO board and Heart Rate Monitoring
-tags: projects, android, ioio, heart-rate-monitor
+tags: projects android ioio heart-rate-monitor
 ---
 
 A few weeks back now, I worked on a project for [iDAT][]. I came in at the end to

--- a/_posts/2013-08-01-debian-ubuntu-dynamic-motd.md
+++ b/_posts/2013-08-01-debian-ubuntu-dynamic-motd.md
@@ -1,6 +1,6 @@
 ---
 title: "Debian/Ubuntu: Dynamic MOTD"
-tags: debian, ubuntu, sysadmin
+tags: debian ubuntu sysadmin
 ---
 
 In doing some client work recently, I noticed that Ubuntu now has a dynamically

--- a/_posts/2013-08-02-automated-backups-with-backup-and-rsyncnet.md
+++ b/_posts/2013-08-02-automated-backups-with-backup-and-rsyncnet.md
@@ -1,6 +1,6 @@
 ---
 title: Automated Backups with backup and Rsync.net
-tags: sysadmin, backups, ruby
+tags: sysadmin backups ruby
 ---
 
 For the past 18 months, I've been meaning to review the way I go about doing backups.

--- a/_posts/2013-08-08-moviesapi.md
+++ b/_posts/2013-08-08-moviesapi.md
@@ -1,6 +1,6 @@
 ---
 title: "moviesapi: A Simple API for UK Cinema Listings"
-tags: ruby, api, rest, young-rewired-state
+tags: ruby api rest young-rewired-state
 ---
 
 This week has been [Young Rewired State][] week. At [YRS i-DAT][] in Plymouth, we've

--- a/_posts/2013-08-13-tweetbot-mute-filters.md
+++ b/_posts/2013-08-13-tweetbot-mute-filters.md
@@ -1,6 +1,6 @@
 ---
 title: Tweetbot Mute Filters
-tags: tweetbot, regex, twitter
+tags: tweetbot regex twitter
 ---
 
 The other day, [I tweeted a link to a regex-based mute filter for Tweetbot][tweet].

--- a/_posts/2013-08-15-mocking-web-requests-vcr-minitest.md
+++ b/_posts/2013-08-15-mocking-web-requests-vcr-minitest.md
@@ -1,6 +1,6 @@
 ---
 title: Mocking Web Requests with VCR and MiniTest
-tags: ruby, testing, minitest, moviesapi, screenscraping
+tags: ruby testing minitest moviesapi screenscraping
 ---
 
 I just released [moviesapi][]. In [the post I introduced it][post], I mentioned 

--- a/_posts/2013-08-27-paste-cleanly.md
+++ b/_posts/2013-08-27-paste-cleanly.md
@@ -1,6 +1,6 @@
 ---
 title: "Alfred Workflow: Paste Cleanly"
-tags: alfred, regex, ruby
+tags: alfred regex ruby
 ---
 
 There is nothing more annoying than seeing, or ending up sharing URLs that look like

--- a/_posts/2014-01-07-annual-review-2013.md
+++ b/_posts/2014-01-07-annual-review-2013.md
@@ -1,6 +1,6 @@
 ---
 title: Annual Review 2013
-tags: annual-review, life, projects
+tags: annual-review life projects
 ---
 
 ## Introduction

--- a/_posts/2014-01-08-ruby-subprocesses-with-stdout-stderr-streams.md
+++ b/_posts/2014-01-08-ruby-subprocesses-with-stdout-stderr-streams.md
@@ -1,6 +1,6 @@
 ---
 title: Ruby Subprocesses with stdout and stderr Streams
-tags: ruby, posix, boxes
+tags: ruby posix boxes
 ---
 
 I've been doing a few things with Ruby which involve controlling and responding to

--- a/_posts/2014-08-18-debugging-sentestingkit-to-xctest-linker-errors.md
+++ b/_posts/2014-08-18-debugging-sentestingkit-to-xctest-linker-errors.md
@@ -1,6 +1,6 @@
 ---
 title: Debugging SenTestingKit to XCTest Linker Errors in Upgraded Xcode Projects
-tags: xcode, testing, sentestingkit, xctest, ios
+tags: xcode testing sentestingkit xctest ios
 ---
 
 There's a couple of (client) projects which I maintain which have been in

--- a/_posts/2014-08-20-custom-pandoc-options-hakyll-4.md
+++ b/_posts/2014-08-20-custom-pandoc-options-hakyll-4.md
@@ -1,6 +1,6 @@
 ---
 title: Custom Pandoc Options with Hakyll 4
-tags: pandoc, hakyll, haskell
+tags: pandoc hakyll haskell
 ---
 
 [Pandoc][] has a huge set of extensions which are not enabled by default and

--- a/_posts/2014-08-20-site-v4.md
+++ b/_posts/2014-08-20-site-v4.md
@@ -1,6 +1,6 @@
 ---
 title: Site v4
-tags: site, release
+tags: site release
 ---
 
 If you're reading this, it means that I successfully rolled-out the fourth[^1]

--- a/_posts/2014-10-12-reserve-caching-with-expire-keys-redis.md
+++ b/_posts/2014-10-12-reserve-caching-with-expire-keys-redis.md
@@ -1,6 +1,6 @@
 ---
 title: "Reserve: Caching with Expiring Keys and Redis"
-tags: redis, ruby, caching
+tags: redis ruby caching
 ---
 
 I've just released a new RubyGem which makes caching objects (and allowing

--- a/_posts/2014-11-29-structuring-sinatra-applications.md
+++ b/_posts/2014-11-29-structuring-sinatra-applications.md
@@ -1,6 +1,6 @@
 ---
 title: Structuring Sinatra Applications
-tags: sinatra, ruby
+tags: sinatra ruby
 ---
 
 [Sinatra] is a cool little framework for building web tools in Ruby. I've been

--- a/_posts/2014-12-15-postmark-with-sinatra.md
+++ b/_posts/2014-12-15-postmark-with-sinatra.md
@@ -1,6 +1,6 @@
 ---
 title: Using Postmark with Sinatra
-tags: ruby, sinatra, mail, postmark
+tags: ruby sinatra mail postmark
 ---
 
 I usually use [Postmark][] for outgoing transactional email, I find this to be

--- a/_posts/2015-03-11-conditionally-chaining-activerecord-queries.md
+++ b/_posts/2015-03-11-conditionally-chaining-activerecord-queries.md
@@ -1,6 +1,6 @@
 ---
 title: Conditionally Chaining ActiveRecord Queries
-tags: ruby, rails, activerecord
+tags: ruby rails activerecord
 ---
 
 Sometimes, [ActiveRecord][] queries can get pretty complex, especially if

--- a/_posts/2015-03-28-transparent-proxy-virtual-machines-mitmproxy.md
+++ b/_posts/2015-03-28-transparent-proxy-virtual-machines-mitmproxy.md
@@ -1,6 +1,6 @@
 ---
 title: Setting up Transparent Proxying VMs for mitmproxy
-tags: vmware, transparent-proxy, mitmproxy
+tags: vmware transparent-proxy mitmproxy
 ---
 
 I seem to do a lot with Virtual Machines and this was no different. I'd started

--- a/_posts/2015-04-14-static-sites-with-rack-sass.md
+++ b/_posts/2015-04-14-static-sites-with-rack-sass.md
@@ -1,6 +1,6 @@
 ---
 title: Static Sites with Rack and Sass
-tags: ruby, rack, sass
+tags: ruby rack sass
 ---
 
 [Rack][] is the (excellent) common denominator web library for Ruby. [Sass][]

--- a/_posts/2015-07-06-fixing-problems-with-yosemite-server.md
+++ b/_posts/2015-07-06-fixing-problems-with-yosemite-server.md
@@ -1,7 +1,7 @@
 ---
 title: Fixing Problems with OS X Yosemite Server
 published: 2015-07-06 10:51:50 +0000
-tags: osx, yosemite, server
+tags: osx yosemite server
 ---
 
 I have a hosted Mac mini with [Macminicolo][mmc] that I use for a range of

--- a/_posts/2015-07-06-osx-server-providing-internal-dns.md
+++ b/_posts/2015-07-06-osx-server-providing-internal-dns.md
@@ -1,7 +1,7 @@
 ---
 title: Providing Internal DNS with OS X Server
 published: 2015-07-06 14:20:00 +0000
-tags: osx, server, dns
+tags: osx server dns
 ---
 
 Picture the scene: You've got a hosted Mac somewhere on the internet, you

--- a/_posts/2015-07-07-installing-jenkins-osx-yosemite.md
+++ b/_posts/2015-07-07-installing-jenkins-osx-yosemite.md
@@ -1,7 +1,7 @@
 ---
 title: Installing Jenkins on OS X Yosemite
 published: 2015-07-07 11:00:00 +0000
-tags: osx, server, jenkins, ci
+tags: osx server jenkins ci
 ---
 
 [Jenkins][] is a [continuous integration][] (CI) server written in Java. It's

--- a/_posts/2015-07-08-terraform-aws-vpc.md
+++ b/_posts/2015-07-08-terraform-aws-vpc.md
@@ -1,7 +1,7 @@
 ---
 title: "Terraform: AWS VPC with Private and Public Subnets"
 published: 2015-07-08 22:56:07 +0000
-tags: terraform, amazon-web-services
+tags: terraform amazon-web-services
 ---
 
 I'm currently in the process of designing out the architecture for a project

--- a/_posts/2015-07-21-mirroring-bazaar-repositories-with-git.md
+++ b/_posts/2015-07-21-mirroring-bazaar-repositories-with-git.md
@@ -1,7 +1,7 @@
 ---
 title: Mirroring Bazaar Repositories with Git
 published: 2015-07-21 15:57:23 +0000
-tags: git, bazaar
+tags: git bazaar
 ---
 
 [Ubuntu][] uses [bazaar][] as it's source control system, with [Launchpad][] as

--- a/_posts/2016-01-17-docker-via-homebrew.md
+++ b/_posts/2016-01-17-docker-via-homebrew.md
@@ -1,7 +1,7 @@
 ---
 title: Docker via Homebrew
 published: 2016-01-17 16:49:53 +0000
-tags: docker, osx, homebrew
+tags: docker osx homebrew
 ---
 
 On the site, [Docker][] recommend using the [Docker Toolbox][] to get up and


### PR DESCRIPTION
Previously (in Hakyll days), the list of tags was a comma separated list. Jekyll doesn't do that, so recent posts have been correct but older ones have had double commas.

This removes the commas from the existing posts so that they're rendered properly.

    find _posts -type f -name "*.md" -exec sed -i '' -e '/tags:/s/,//g' {} \;