### PR TITLE
Add a tags page and link to tags from posts

### DIFF
--- a/_includes/post_line_item.html
+++ b/_includes/post_line_item.html
@@ -1,0 +1,1 @@
+<a href="{{ include.post.url }}">{{ include.post.title }}</a> &mdash; <time datetime="{{ include.post.date | date_to_xmlschema }}">{{ include.post.date | date_to_long_string: "ordinal" }}</time>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -12,7 +12,7 @@ layout: default
       {% if page.updated_at %}
       Last updated on <time datetime="{{ page.updated_at | date_to_xmlschema }}">{{ page.updated_at | date: "%B %-d, %Y" }}</time>.
       {% endif %}
-      Tagged with: {{ page.tags | array_to_sentence_string }}.
+      Tagged with: {% for tag in page.tags %}<a href='/tags.html#{{tag}}'>{{ tag }}</a>{% if forloop.last == false %}, {% endif %}{% endfor %}.
     </p>
   </footer>
 

--- a/archives.html
+++ b/archives.html
@@ -16,9 +16,7 @@ layout: default
 <ul>
   {% assign date = currentdate %}
   {% endif %}
-  <li>
-    <a href="{{ post.url | prepend: site.baseurl }}">{{ post.title }}</a> &mdash; <time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: "%B %-d, %Y" }}</time>
-  </li>
+  <li>{% include post_line_item.html post=post %}</li>
   {% if forloop.last %}</ul>{% endif %}
 {% endfor %}
 

--- a/index.html
+++ b/index.html
@@ -18,10 +18,7 @@ layout: default
   <ul>
     {% assign week_notes = site.posts | filter_posts: "tags", "includes 'week-notes'" %}
     {% for post in week_notes limit:5 %}
-      <li>
-      <a href="{{ post.url }}">{{ post.title }}</a> &mdash; <time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date_to_long_string: "ordinal" }}</time>
-    </li>
-
+    <li>{% include post_line_item.html post=post %}</li>
     {% endfor %}
   </ul>
 
@@ -30,9 +27,7 @@ layout: default
   <ul>
     {% assign posts = site.posts | filter_posts: "tags", "excludes 'week-notes'" %}
     {% for post in posts limit:5 %}
-    <li>
-      <a href="{{ post.url }}">{{ post.title }}</a> &mdash; <time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date_to_long_string: "ordinal" }}</time>
-    </li>
+    <li>{% include post_line_item.html post=post %}</li>
     {% endfor %}
   </ul>
 </main>

--- a/tags.html
+++ b/tags.html
@@ -1,0 +1,29 @@
+---
+title: Tags
+layout: default
+---
+
+<main>
+  <header>
+    <h2>Tags</h2>
+  </header>
+
+  {% for tag in site.tags %}
+  {% assign t = tag | first %}
+  {% assign posts = tag | last %}
+
+  <h4>
+    <a name="{{t | downcase | replace:" ","-" }}"></a>
+    <a href="/tags.html#{{t | downcase | replace:" ","-" }}">{{ t | downcase }}</a>
+  </h4>
+
+  <ul>
+    {% for post in posts %}
+    {% if post.tags contains t %}
+    <li>{% include post_line_item.html post=post %}</li>
+    {% endif %}
+    {% endfor %}
+  </ul>
+
+  {% endfor %}
+</main>


### PR DESCRIPTION
This takes a simple approach of linking to a single page which has tags on it and anchors to link to the section. Then, we can link to the tags from the posts to go there.

We also extract a partial (using Jekyll includes) to make it nicer to
reuse posts rendered in lists.

Inspired by: https://www.jokecamp.com/blog/listing-jekyll-posts-by-tag/