### PR TITLE
Stop showing "Week Notes" on the homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,20 +13,11 @@ layout: default
     This is the place where I write up what I learn.
   </p>
 
-  <h2>Week Notes</h2>
-
-  <ul>
-    {% assign week_notes = site.posts | filter_posts: "tags", "includes 'week-notes'" %}
-    {% for post in week_notes limit:5 %}
-    <li>{% include post_line_item.html post=post %}</li>
-    {% endfor %}
-  </ul>
-
   <h2>Articles</h2>
 
   <ul>
     {% assign posts = site.posts | filter_posts: "tags", "excludes 'week-notes'" %}
-    {% for post in posts limit:5 %}
+    {% for post in posts limit:10 %}
     <li>{% include post_line_item.html post=post %}</li>
     {% endfor %}
   </ul>


### PR DESCRIPTION
Now the last Week Note was back in 2022, it makes the overall site look like it's not being updated as it's the first block. This removes the whole section and increases the list of normal posts to show more.