### PR TITLE
Add a meta tag for Fediverse author attribution

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -44,6 +44,7 @@
     <meta property="og:description" content="{% if page.excerpt != nil %}{{page.excerpt | strip_html }}{% else %}{{ site.description }}{% endif %}" />
     <meta property="og:locale" content="en_UK" />
     <meta property="og:type" content="article" />
+    <meta name="fediverse:creator" content="@nick@nickcharlton.net">
   </head>
 
   <body>


### PR DESCRIPTION
https://blog.joinmastodon.org/2024/07/highlighting-journalism-on-mastodon/
https://rknight.me/blog/highlighting-journalism-with-the-fediverse-creator-tag/